### PR TITLE
fixed bug #18 where requesting payment types resulted in all payment …

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -19,7 +19,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             view_name='payment',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
+        fields = ('id', 'url', 'merchant_name', 'account_number', 'customer',
                   'expiration_date', 'create_date')
 
 
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
…types being returned. Payment types saved exclusively by the current user are only being returned now.


## Changes

- in `paymenttype.py`, added "customer" field to the `PaymentSerializer`.
- in `paymenttype.py`, changed `customer__id` to `customer`, and changed the `customer` declaration to `Customer.objects.get(user=request.auth.user)`


## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Request paymenttypes from the API
- [ ] 'GET' is successful if the request returns a 200 status with a single paymenttype returned with an id of 4
- [ ] To test further, create a payment type and 'GET' all payment types again

