### PR TITLE
Rbg bug19 payment type info is incorrect

### DIFF
--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -34,8 +34,8 @@ class Payments(ViewSet):
         new_payment = Payment()
         new_payment.merchant_name = request.data["merchant_name"]
         new_payment.account_number = request.data["account_number"]
-        new_payment.expiration_date = request.data["create_date"]
-        new_payment.create_date = request.data["expiration_date"]
+        new_payment.expiration_date = request.data["expiration_date"]
+        new_payment.create_date = request.data["create_date"]
         customer = Customer.objects.get(user=request.auth.user)
         new_payment.customer = customer
         new_payment.save()

--- a/bangazonapi/views/paymenttype.py
+++ b/bangazonapi/views/paymenttype.py
@@ -19,7 +19,7 @@ class PaymentSerializer(serializers.HyperlinkedModelSerializer):
             view_name='payment',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'merchant_name', 'account_number',
+        fields = ('id', 'url', 'merchant_name', 'account_number', 'customer',
                   'expiration_date', 'create_date')
 
 
@@ -81,10 +81,10 @@ class Payments(ViewSet):
         """Handle GET requests to payment type resource"""
         payment_types = Payment.objects.all()
 
-        customer_id = self.request.query_params.get('customer', None)
+        customer = Customer.objects.get(user=request.auth.user)
 
-        if customer_id is not None:
-            payment_types = payment_types.filter(customer__id=customer_id)
+        if customer is not None:
+            payment_types = payment_types.filter(customer__id=customer.id)
 
         serializer = PaymentSerializer(
             payment_types, many=True, context={'request': request})


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- In `paymenttype.py`, within the "create" method, line 37, `new_payment.expiration_date` has now been correctly set to "expiration_date".
- The same was done on line 38 for `new_payment.create_date`.


## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] Request all paymenttypes to see if any old paymenttypes exist that were created before the fix
- [ ] Create a new paymenttype with the correct dates
- [ ] Request all paymenttypes once more, the new paymenttype should be returned.
-  NOTE: All faulty paymenttypes will still exist and be returned when requested unless manually deleted. Keep this in mind when testing. ( The old faulty paymenttypes can be used in testing to check against any newly created ones.)
