### PR TITLE
fixed bug #20 which prevented the user from deleting specific line it…

### DIFF
--- a/bangazonapi/views/lineitem.py
+++ b/bangazonapi/views/lineitem.py
@@ -18,6 +18,7 @@ class LineItemSerializer(serializers.HyperlinkedModelSerializer):
         )
         fields = ('id', 'url', 'order', 'product')
 
+
 class LineItems(ViewSet):
     """Line items for Bangazon orders"""
 
@@ -51,9 +52,11 @@ class LineItems(ViewSet):
         try:
             # line_item = OrderProduct.objects.get(pk=pk)
             customer = Customer.objects.get(user=request.auth.user)
-            line_item = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            line_item = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
 
-            serializer = LineItemSerializer(line_item, context={'request': request})
+            serializer = LineItemSerializer(
+                line_item, context={'request': request})
 
             return Response(serializer.data)
 
@@ -76,7 +79,10 @@ class LineItems(ViewSet):
         """
         try:
             customer = Customer.objects.get(user=request.auth.user)
-            order_product = OrderProduct.objects.get(pk=pk, order__customer=customer)
+            order_product = OrderProduct.objects.get(
+                pk=pk, order__customer=customer)
+
+            order_product.delete()
 
             return Response({}, status=status.HTTP_204_NO_CONTENT)
 


### PR DESCRIPTION
## Changes

- In `lineitem.py`, added `order_product.delete()` to the "destroy" method. 


## Testing

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] 'GET' the user's cart and see what products/line_items it contains
- [ ] 'POST' an item to the cart if there are none
- [ ] Remove an item from the cart by running a 'DELETE' request with the address `http://localhost:8000/cart/:id` where `:id` is equal to the product's id.
