### PR TITLE
Rbg bug23 products being added to closed order

### DIFF
--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -81,8 +81,7 @@ class Profile(ViewSet):
             }
         """
         try:
-            # current_user = Customer.objects.get(user=4) <-- This won't work because codebase is set up to check for tokens
-            # <-- 'Customer' matching query doesn't exist
+
             current_user = Customer.objects.get(user=request.auth.user)
             current_user.recommends = Recommendation.objects.filter(
                 recommender=current_user)
@@ -237,8 +236,10 @@ class Profile(ViewSet):
             """
 
             try:
+
                 open_order = Order.objects.get(
                     customer=current_user, payment_type=None)
+                # open_order.customer = current_user
                 print(current_user)
                 print(open_order)
             except Order.DoesNotExist as ex:

--- a/bangazonapi/views/profile.py
+++ b/bangazonapi/views/profile.py
@@ -237,7 +237,9 @@ class Profile(ViewSet):
             """
 
             try:
-                open_order = Order.objects.get(customer=current_user)
+                open_order = Order.objects.get(
+                    customer=current_user, payment_type=None)
+                print(current_user)
                 print(open_order)
             except Order.DoesNotExist as ex:
                 open_order = Order()


### PR DESCRIPTION
## Changes

- In `profile.py`, within the "POST" method, on lines 241-242, added `payment_type=None` to the `open_order` definition. This makes the `open_order` definition in the "POST" method match the definition in the "GET". I believe this is why this fix provides functionality for the "POST" method to create open orders that have no payment type, thus preventing the database from recognizing closed orders as open orders.  


## Requests / Responses

**Request**

POST `/profile/cart` Adds a new product to the cart

```json
{
   "product_id": 88
}
```

**Response**

HTTP/1.1 201 OK

```json
"id": 16,
    "product": {
        "id": 88,
        "name": "Element",
        "price": 1727.41,
        "number_sold": 0,
        "description": "2003 Honda",
        "quantity": 3,
        "created_date": "2019-05-28",
        "location": "Dukoh",
        "image_path": null,
        "average_rating": 0
    }
}
```
You can then GET /profile/cart to check if the item has been added properly and with the correct information.

## Testing

Description of how to test code...

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database
- [ ] GET the cart to see what exists within it
- [ ] DELETE any items in the cart that aren't needed/wanted
- [ ] POST an item to the cart
- [ ] GET the cart to check if item was added correctly and with the correct information


## Related Issues

- Fixes #23